### PR TITLE
Fix stop time in fast mode

### DIFF
--- a/src/nexus_streamer/event_data_source.py
+++ b/src/nexus_streamer/event_data_source.py
@@ -136,6 +136,14 @@ class EventDataSource:
             self._group["event_time_zero"]
         )
 
+    @property
+    def final_timestamp(self) -> int:
+        # Last pulse time is good enough, we won't try to find the last event in the last pulse
+        return (
+            self._convert_pulse_time(self._event_time_zero[-1])
+            + self._pulse_time_offset_ns
+        )
+
     def get_data(
         self,
     ) -> Generator[Tuple[Optional[np.ndarray], Optional[np.ndarray], int], None, None]:
@@ -214,6 +222,14 @@ class FakeEventDataSource:
         self._rng = np.random.default_rng(12345)
 
         self.name = group.name.split("/")[-1]
+
+    @property
+    def final_timestamp(self) -> int:
+        # Last pulse time is good enough, we won't try to find the last event in the last pulse
+        return (
+            self._convert_pulse_time(self._event_time_zero[-1])
+            + self._pulse_time_offset_ns
+        )
 
     def get_data(
         self,

--- a/src/nexus_streamer/isis_data_source.py
+++ b/src/nexus_streamer/isis_data_source.py
@@ -32,6 +32,13 @@ class IsisDataSource:
             logger, nexus_file, "raw_data_1/framelog/period_log/value", "period_log"
         )
 
+    @property
+    def final_timestamp(self) -> int:
+        # We don't need the final timestamp from these data as they are
+        # published for each pulse, we will get the final pulse time
+        # from the event data source instead
+        return 0
+
     def get_data(
         self,
     ) -> Generator[Dict, None, None]:

--- a/src/nexus_streamer/launch_nexus_streamer.py
+++ b/src/nexus_streamer/launch_nexus_streamer.py
@@ -94,11 +94,14 @@ async def publish_run(producer: KafkaProducer, run_id: int, args, logger):
             )
 
             # The last timestamp will be the stop time for the run
-            stop_time_ns = max(
-                [
-                    source.final_timestamp
-                    for source in event_data_sources + log_data_sources  # type: ignore
-                ]
+            stop_time_ns = (
+                max(
+                    [
+                        source.final_timestamp
+                        for source in event_data_sources + log_data_sources  # type: ignore
+                    ]
+                )
+                + start_time_delta_ns
             )
 
             publish_run_start_message(

--- a/src/nexus_streamer/log_data_source.py
+++ b/src/nexus_streamer/log_data_source.py
@@ -68,6 +68,10 @@ class LogDataSource:
             )
             raise BadSource()
 
+    @property
+    def final_timestamp(self) -> int:
+        return self._convert_time(self._time_dataset[-1]) + self._time_offset_ns
+
     def get_data(self) -> Generator[Tuple[Optional[np.ndarray], int], None, None]:
         """
         Returns None instead of data when there are no more data

--- a/src/nexus_streamer/publish_run_message.py
+++ b/src/nexus_streamer/publish_run_message.py
@@ -1,6 +1,5 @@
 from streaming_data_types.run_start_pl72 import serialise_pl72, DetectorSpectrumMap
 from uuid import uuid4
-from time import time_ns
 from .kafka_producer import KafkaProducer
 from typing import Optional
 import numpy as np
@@ -15,12 +14,12 @@ def publish_run_start_message(
     topic: str,
     map_det_ids: Optional[np.ndarray],
     map_spec_nums: Optional[np.ndarray],
+    streamer_start_time: int,
     stop_time_ns: int,
 ) -> str:
     filename = f"FromNeXusStreamer_{run_number}.nxs"
     job_id = str(uuid4())
-    start_time_ns = time_ns()
-    start_time_ms = int(start_time_ns * 0.000001)
+    start_time_ms = int(streamer_start_time * 0.000001)
     det_spec_map = None
     if map_spec_nums is not None:
         det_spec_map = DetectorSpectrumMap(
@@ -41,5 +40,5 @@ def publish_run_start_message(
         broker=broker,
         detector_spectrum_map=det_spec_map,
     )
-    producer.produce(topic, run_start_payload, start_time_ns)
+    producer.produce(topic, run_start_payload, streamer_start_time)
     return job_id


### PR DESCRIPTION
Closes #23

Include stop time in run start message instead of sending a separate run stop message.
When in normal "fast" mode the current time is used as the stop time of the run and data timestamps are in the past. This means consumers do not end up consuming all the data and then having to wait until a stop time in the future.